### PR TITLE
*: Use gopkg.in/yaml.v3 instead of sigs.k8s.io/yaml

### DIFF
--- a/.idea/go-memcached.iml
+++ b/.idea/go-memcached.iml
@@ -9,6 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/bazel-go-memcached" />
       <excludeFolder url="file://$MODULE_DIR$/bazel-out" />
       <excludeFolder url="file://$MODULE_DIR$/bazel-testlogs" />
+      <excludeFolder url="file://$MODULE_DIR$/.sl" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,15 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:prefix go.f110.dev/go-memcached
 gazelle(name = "gazelle")
 
+gazelle(
+    name = "gazelle-update-repos",
+    args = [
+        "-from_file=go.mod",
+        "-prune",
+    ],
+    command = "update-repos",
+)
+
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 configure_make(
@@ -18,14 +27,14 @@ configure_make(
 
 configure_make(
     name = "memcached",
-    install_prefix = "install",
-    lib_source = "@memcached//:all",
-    out_include_dir = "",
-    out_binaries = ["memcached"],
-    deps = ["libevent"],
     configure_options = [
         "CXXFLAGS=\"\"",
         "CFLAGS=\"\"",
     ],
+    install_prefix = "install",
+    lib_source = "@memcached//:all",
+    out_binaries = ["memcached"],
+    out_include_dir = "",
     visibility = ["//visibility:public"],
+    deps = ["libevent"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,13 @@ go_register_toolchains(version = "1.20.1")
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
+go_repository(
+    name = "in_gopkg_yaml_v3",
+    importpath = "gopkg.in/yaml.v3",
+    sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+    version = "v3.0.1",
+)
+
 gazelle_dependencies()
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
@@ -44,16 +51,16 @@ all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//v
 http_archive(
     name = "libevent",
     build_file_content = all_content,
-    strip_prefix = "libevent-2.1.8-stable",
     sha256 = "965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2",
+    strip_prefix = "libevent-2.1.8-stable",
     urls = ["https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz"],
 )
 
 http_archive(
     name = "memcached",
     build_file_content = all_content,
-    strip_prefix = "memcached-1.6.12",
     sha256 = "f291a35f82ef9756ed1d952879ef5f4be870f932bdfcb2ab61356609abf82346",
+    strip_prefix = "memcached-1.6.12",
     urls = ["http://www.memcached.org/files/memcached-1.6.12.tar.gz"],
 )
 
@@ -62,18 +69,4 @@ go_repository(
     importpath = "gopkg.in/check.v1",
     sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",
     version = "v0.0.0-20161208181325-20d25e280405",
-)
-
-go_repository(
-    name = "in_gopkg_yaml_v2",
-    importpath = "gopkg.in/yaml.v2",
-    sum = "h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=",
-    version = "v2.2.4",
-)
-
-go_repository(
-    name = "io_k8s_sigs_yaml",
-    importpath = "sigs.k8s.io/yaml",
-    sum = "h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=",
-    version = "v1.1.0",
 )

--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -18,12 +18,12 @@ go_test(
         "client_test.go",
         "ring_test.go",
     ],
+    data = [
+        "//:memcached",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//errors:go_default_library",
         "//testutil:go_default_library",
-    ],
-    data = [
-        "//:memcached",
     ],
 )

--- a/cluster/BUILD.bazel
+++ b/cluster/BUILD.bazel
@@ -11,12 +11,12 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["cluster_test.go"],
+    data = [
+        "//:memcached",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//client:go_default_library",
         "//testutil:go_default_library",
-    ],
-    data = [
-        "//:memcached",
     ],
 )

--- a/cmd/router/BUILD.bazel
+++ b/cmd/router/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "//cluster:go_default_library",
         "//proxy:go_default_library",
         "//server:go_default_library",
-        "@io_k8s_sigs_yaml//:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
     ],
 )
 

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 
 	"go.f110.dev/go-memcached/client"
 	"go.f110.dev/go-memcached/cluster"
@@ -16,14 +16,14 @@ import (
 )
 
 type Server struct {
-	Name string `json:"name"`
-	Host string `json:"host"`
-	Port int    `json:"port"`
+	Name string `yaml:"name"`
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
 }
 
 type Config struct {
-	Primary   []Server `json:"primary"`
-	Secondary []Server `json:"secondary"`
+	Primary   []Server `yaml:"primary"`
+	Secondary []Server `yaml:"secondary"`
 }
 
 func connectServers(servers []Server) []*client.ServerWithMetaProtocol {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module go.f110.dev/go-memcached
 
 go 1.20
 
-require sigs.k8s.io/yaml v1.1.0
-
-require gopkg.in/yaml.v2 v2.2.4 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
-sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
*: Use gopkg.in/yaml.v3 instead of sigs.k8s.io/yaml

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/go-memcached/pull/6).
* __->__ #6
* #5
* #4
* #3
* #2
* #1
