### PR TITLE
client: Add heartbeat and reconnect options

### DIFF
--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     srcs = [
         "client_test.go",
         "ring_test.go",
+        "server_test.go",
     ],
     data = [
         "//:memcached",


### PR DESCRIPTION
client: Add heartbeat and reconnect options

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/go-memcached/pull/9).
* __->__ #9
* #8
* #7
